### PR TITLE
Update line 33 with the new html class

### DIFF
--- a/webscraping_example.py
+++ b/webscraping_example.py
@@ -30,7 +30,7 @@ except TimeoutException:
 # with selenium elements of the titles.
 
 # find_elements_by_xpath - Returns an array of selenium objects.
-titles_element = browser.find_elements_by_xpath("//a[@class='text-bold']")
+titles_element = browser.find_elements_by_xpath("//a[@class='text-bold flex-auto']")
 
 # List Comprehension to get the actual repo titles and not the selenium objects.
 titles = [x.text for x in titles_element]


### PR DESCRIPTION
The HTML's class for scrapping repo titles have change.
<img width="1423" alt="Capture d’écran 2019-04-02 à 23 25 41" src="https://user-images.githubusercontent.com/17741510/55437212-aac8f080-559e-11e9-9144-ddad0c6c75af.png">
